### PR TITLE
Enable IntelMausi to support Ethernet

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -305,7 +305,7 @@
 				<key>Comment</key>
 				<string>Intel Ethernet LAN</string>
 				<key>Enabled</key>
-				<false/>
+				<true/>
 				<key>ExecutablePath</key>
 				<string>Contents/MacOS/IntelMausi</string>
 				<key>MaxKernel</key>


### PR DESCRIPTION
Small fix for enabling the IntelMausi kext. 
With this fix I was able to get the onboard Ethernet port working.