### PR TITLE
Fix Kexts copy

### DIFF
--- a/create-efi.sh
+++ b/create-efi.sh
@@ -119,7 +119,6 @@ download_extra_kexts() {
     for k in "${!EXTRA_KEXTS_DOWNLOAD_LIST[@]}"; do
       wget -nv -c --cut-dirs=5 -nH -P "${TMP_DIR}/Kexts/${k}" -r -np "${EXTRA_KEXTS_DOWNLOAD_LIST[$k]}"
     done
-    ls -alhR "${TMP_DIR}/Kexts"
   else
     echo "Copying extra Kexts..."
     cp -rv "${BASE_DIR}/Kexts/" "${TMP_DIR}/"

--- a/create-efi.sh
+++ b/create-efi.sh
@@ -235,7 +235,7 @@ copy_oc_drivers() {
 #   TMP_DIR
 copy_kexts() {
   echo "Copying Kexts to EFI/Kexts directory..."
-  cp -vr "${TMP_DIR}/Kexts/" "${BASE_OC_DIR}"/
+  cp -vr "${TMP_DIR}/Kexts" "${BASE_OC_DIR}"/
   cp -vr "${TMP_DIR}/${PKG_KEXT_APPLEALC}"/AppleALC.kext "${BASE_OC_DIR}"/Kexts/
   cp -vr "${TMP_DIR}/${PKG_KEXT_INTELMAUSI}"/IntelMausi.kext "${BASE_OC_DIR}"/Kexts/
   cp -vr "${TMP_DIR}/${PKG_KEXT_LILU}"/Lilu.kext "${BASE_OC_DIR}"/Kexts/


### PR DESCRIPTION
Linked issue - #16.

When `coreutils` are not installed/used, `USBMap.kext` is copied to wrong directory (one level up). Remove trailing slash to make it work for both BSD and POSIX `cp` versions.

Remove debugging `ls` call.