### PR TITLE
Add GNU Coreutils as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ BIOS [download page](https://www.asus.com/Motherboards/ROG-MAXIMUS-XI-HERO/HelpD
 [![Build Status](https://travis-ci.org/vovinacci/OpenCore-ASUS-ROG-MAXIMUS-XI-HERO.svg?branch=master)](https://travis-ci.org/vovinacci/OpenCore-ASUS-ROG-MAXIMUS-XI-HERO)
 
 Requirements:
+
 - [bash](https://www.gnu.org/software/bash/) > 4.0
 - [Coreutils](https://www.gnu.org/software/coreutils/) > 8.15
 - [OpenSSL](https://www.openssl.org/) 1.1 (required for `wget`)

--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ BIOS [download page](https://www.asus.com/Motherboards/ROG-MAXIMUS-XI-HERO/HelpD
 [![Build Status](https://travis-ci.org/vovinacci/OpenCore-ASUS-ROG-MAXIMUS-XI-HERO.svg?branch=master)](https://travis-ci.org/vovinacci/OpenCore-ASUS-ROG-MAXIMUS-XI-HERO)
 
 Requirements:
-
 - [bash](https://www.gnu.org/software/bash/) > 4.0
+- [Coreutils](https://www.gnu.org/software/coreutils/) > 8.15
 - [OpenSSL](https://www.openssl.org/) 1.1 (required for `wget`)
 - [wget](https://www.gnu.org/software/wget/)
 
 Should you use [Homebrew](https://brew.sh/) on macOS, install it with
 ```
-brew install bash openssl@1.1 wget
+brew install bash coreutils openssl@1.1 wget
 ```
 
 To create EFI folder, there's no need to clone this repository, just run


### PR DESCRIPTION
Issue #16 

Add GNU Coreutils as a dependency - provides `realpath`.