### PR TITLE
Change alc_layout_id to layout 1

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -219,7 +219,7 @@
 			<key>PciRoot(0x0)/Pci(0x1F,0x3)</key>
 			<dict>
 				<key>alc-layout-id</key>
-				<data>CwAAAA==</data>
+				<data>AQAAAA==</data>
 			</dict>
 		</dict>
 		<key>Delete</key>


### PR DESCRIPTION
The default alc_layout_id layout 7 did not work on my Asus Rog Maximus XI Hero so I change it to layout 1. 