### PR TITLE
Upgrade OpenCore to 0.6.4

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -162,6 +162,8 @@
 		</array>
 		<key>Quirks</key>
 		<dict>
+			<key>AllowRelocationBlock</key>
+			<false/>
 			<key>AvoidRuntimeDefrag</key>
 			<true/>
 			<key>DevirtualiseMmio</key>
@@ -393,12 +395,12 @@
 		</array>
 		<key>Emulate</key>
 		<dict>
-			<key>DummyPowerManagement</key>
-			<false/>
 			<key>Cpuid1Data</key>
 			<data></data>
 			<key>Cpuid1Mask</key>
 			<data></data>
+			<key>DummyPowerManagement</key>
+			<false/>
 			<key>MaxKernel</key>
 			<string></string>
 			<key>MinKernel</key>
@@ -415,10 +417,10 @@
 				<string></string>
 				<key>Enabled</key>
 				<false/>
-				<key>Identifier</key>
-				<string>com.apple.iokit.IONetworkingFamily</string>
 				<key>ExecutablePath</key>
 				<string>Contents/MacOS/IONetworkingFamily</string>
+				<key>Identifier</key>
+				<string>com.apple.iokit.IONetworkingFamily</string>
 				<key>MaxKernel</key>
 				<string>13.99.99</string>
 				<key>MinKernel</key>
@@ -720,6 +722,8 @@
 				<string>CustomOS</string>
 				<key>Path</key>
 				<string>PciRoot(0x0)/Pci(0x1,0x1)/Pci(0x0,0x0)/NVMe(0x1,11-22-33-44-55-66-77-88)/HD(1,GPT,00000000-0000-0000-0000-000000000000,0x800,0x64000)/\EFI\BOOT\BOOTX64.EFI</string>
+				<key>TextMode</key>
+				<false/>
 			</dict>
 		</array>
 		<key>Security</key>
@@ -731,6 +735,8 @@
 			<key>ApECID</key>
 			<integer>0</integer>
 			<key>AuthRestart</key>
+			<true/>
+			<key>BlacklistAppleUpdate</key>
 			<true/>
 			<key>BootProtect</key>
 			<string>Bootstrap</string>
@@ -821,12 +827,12 @@
 				<data>Rg==</data>
 				<key>boot-args</key>
 				<string>keepsyms=1</string>
-				<key>run-efi-updater</key>
-				<string>No</string>
 				<key>csr-active-config</key>
 				<data>AAAAAA==</data>
 				<key>prev-lang:kbd</key>
 				<string>uk:19518</string>
+				<key>run-efi-updater</key>
+				<string>No</string>
 			</dict>
 		</dict>
 		<key>Delete</key>
@@ -863,6 +869,8 @@
 				<string>bluetoothInternalControllerInfo</string>
 				<string>flagstate</string>
 				<string>fmm-computer-name</string>
+				<string>fmm-mobileme-token-FMM</string>
+				<string>fmm-mobileme-token-FMM-BridgeHasAccount</string>
 				<string>nvda_drv</string>
 				<string>prev-lang:kbd</string>
 			</array>
@@ -888,8 +896,6 @@
 		<dict>
 			<key>AdviseWindows</key>
 			<false/>
-			<key>SystemMemoryStatus</key>
-			<string>Auto</string>
 			<key>MLB</key>
 			<string>{{BOARDSERIAL}}</string>
 			<key>ProcessorType</key>
@@ -898,6 +904,8 @@
 			<data>{{MACADDRESS}}</data>
 			<key>SpoofVendor</key>
 			<true/>
+			<key>SystemMemoryStatus</key>
+			<string>Auto</string>
 			<key>SystemProductName</key>
 			<string>iMac19,1</string>
 			<key>SystemSerialNumber</key>
@@ -944,7 +952,7 @@
 			<key>MinimumVolume</key>
 			<integer>20</integer>
 			<key>PlayChime</key>
-			<false/>
+			<string>Auto</string>
 			<key>VolumeAmplifier</key>
 			<integer>0</integer>
 		</dict>
@@ -1065,26 +1073,26 @@
 			<dict>
 				<key>Address</key>
 				<integer>268435456</integer>
-				<key>Type</key>
-				<string>Reserved</string>
 				<key>Comment</key>
 				<string>HD3000: IGPU memory corruption errata</string>
 				<key>Enabled</key>
 				<false/>
 				<key>Size</key>
 				<integer>268435456</integer>
+				<key>Type</key>
+				<string>Reserved</string>
 			</dict>
 			<dict>
 				<key>Address</key>
 				<integer>569344</integer>
-				<key>Type</key>
-				<string>RuntimeCode</string>
 				<key>Comment</key>
 				<string>Fix black screen on wake from hibernation for Lenovo Thinkpad T490</string>
 				<key>Enabled</key>
 				<false/>
 				<key>Size</key>
 				<integer>4096</integer>
+				<key>Type</key>
+				<string>RuntimeCode</string>
 			</dict>
 		</array>
 	</dict>

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ You may find great installation guide [here](https://dortania.github.io/OpenCore
 
 ## OpenCore
 
-- [OpenCore 0.6.3](https://github.com/acidanthera/OpenCorePkg/releases/tag/0.6.3)
+> :warning: **If you are updating from OpenCore 0.6.3**: Ensure to read [this comment](https://github.com/acidanthera/bugtracker/issues/1222#issuecomment-739241310) first. :warning:
+
+- [OpenCore 0.6.4](https://github.com/acidanthera/OpenCorePkg/releases/tag/0.6.4)
 - [OpenCore Install Guide](https://dortania.github.io/OpenCore-Install-Guide/)
 - [OpenCore Configuration Sanity Checker](https://opencore.slowgeek.com/)
 
@@ -101,11 +103,11 @@ Resulting [USBMap.kext](Kexts/USBMap.kext) is used.
 
 ### Kext
 
-- [AppleALC 1.5.4](https://github.com/acidanthera/AppleALC/releases/tag/1.5.4)
+- [AppleALC 1.5.5](https://github.com/acidanthera/AppleALC/releases/tag/1.5.5)
 - [IntelMausi 1.0.4](https://github.com/acidanthera/IntelMausi/releases/tag/1.0.4)
-- [Lilu 1.4.9](https://github.com/acidanthera/Lilu/releases/tag/1.4.9)
-- [VirtualSMC 1.1.8](https://github.com/acidanthera/VirtualSMC/releases/tag/1.1.8) (`SMCProcessor.kext`, `SMCSuperIO.kext`)
-- [WhateverGreen 1.4.4](https://github.com/acidanthera/WhateverGreen/releases/tag/1.4.4)
+- [Lilu 1.5.0](https://github.com/acidanthera/Lilu/releases/tag/1.5.0)
+- [VirtualSMC 1.1.9](https://github.com/acidanthera/VirtualSMC/releases/tag/1.1.9) (`SMCProcessor.kext`, `SMCSuperIO.kext`)
+- [WhateverGreen 1.4.5](https://github.com/acidanthera/WhateverGreen/releases/tag/1.4.5)
 
 ### Resources
 

--- a/create-efi.sh
+++ b/create-efi.sh
@@ -29,12 +29,12 @@ run-on-trap() {
 }
 
 # Package versions. Set desired versions here.
-readonly OPENCORE_VERSION="0.6.3"
-readonly KEXT_APPLEALC_VERSION="1.5.4"
+readonly OPENCORE_VERSION="0.6.4"
+readonly KEXT_APPLEALC_VERSION="1.5.5"
 readonly KEXT_INTELMAUSI_VERSION="1.0.4"
-readonly KEXT_LILU_VERSION="1.4.9"
-readonly KEXT_VIRTUALSMC_VERSION="1.1.8"
-readonly KEXT_WHATEVERGREEN_VERSION="1.4.4"
+readonly KEXT_LILU_VERSION="1.5.0"
+readonly KEXT_VIRTUALSMC_VERSION="1.1.9"
+readonly KEXT_WHATEVERGREEN_VERSION="1.4.5"
 
 # Installation settings
 # Any non-zero value turns on local file copy, instead of downloading.


### PR DESCRIPTION
Tested locally - `OK`.

Pending [OpenCore Sanity Checker](https://opencore.slowgeek.com) `0.6.4` support to ensure that proper configuration is in place.