### PR TITLE
Update macOS to 11.4 (20F71), update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Various basic checks
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Other accessories:
 
 ## macOS
 
-macOS Big Sur version 11.3.1 (20E241) with FileVault 2 enabled.
+macOS Big Sur version 11.4 (20F71) with FileVault 2 enabled.
 
 You may find great installation guide [here](https://dortania.github.io/OpenCore-Install-Guide/installer-guide/).
 

--- a/create-efi.sh
+++ b/create-efi.sh
@@ -295,7 +295,7 @@ function copy_oc_resources() {
   cp -v "${TMP_DIR}/${PKG_OC_BINDATA}/OcBinaryData-master/Resources/Audio/"AXEFIAudio_en_*.mp3 "${BASE_OC_DIR}"/Resources/Audio/
   cp -v "${TMP_DIR}/${PKG_OC_BINDATA}/OcBinaryData-master/Resources/Audio/"OCEFIAudio_en_*.mp3 "${BASE_OC_DIR}"/Resources/Audio/
   cp -v "${TMP_DIR}/${PKG_OC_BINDATA}/OcBinaryData-master/Resources/Font/"* "${BASE_OC_DIR}"/Resources/Font/
-  cp -v "${TMP_DIR}/${PKG_OC_BINDATA}/OcBinaryData-master/Resources/Image/"* "${BASE_OC_DIR}"/Resources/Image/
+  cp -v "${TMP_DIR}/${PKG_OC_BINDATA}/OcBinaryData-master/Resources/Image/"*.icns "${BASE_OC_DIR}"/Resources/Image/
   cp -v "${TMP_DIR}/${PKG_OC_BINDATA}/OcBinaryData-master/Resources/Label/"* "${BASE_OC_DIR}"/Resources/Label/
   # Disable globbing back
   set -f


### PR DESCRIPTION
- Update macOS to `11.4` (`20F71`)
- Update pre-commit hook version to `v4.0.1`
- Fix `create-efi.sh` to omit directories when copying images from `OcBinaryData` repository.