### PR TITLE
Upgrade OpenCore to 0.7.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ SHELL := /usr/bin/env bash
 PRINT_TARGET = @echo "--> $@"
 # Default make goal
 .DEFAULT_GOAL := help
+# Required OpenCore version
+REQUIRED_OPENCORE_VERSION = $(shell grep 'readonly OPENCORE_VERSION=' create-efi.sh | awk -F'"' '{ print $$2; }')
 
 ## Targets
 .PHONY: clean
@@ -49,11 +51,11 @@ lint:  ## Run linter checks
 .PHONY: oc_get_ref_config
 oc_get_ref_config: clean  ## Download latest OpenCore reference configuration file to 'OC/Sample.plist' (used for debugging changes)
 	$(PRINT_TARGET)
-	@echo "Downloading 'https://raw.githubusercontent.com/acidanthera/OpenCorePkg/master/Docs/Sample.plist' to 'OC/Sample.plist'..."
+	@echo "Downloading 'https://raw.githubusercontent.com/acidanthera/OpenCorePkg/$(REQUIRED_OPENCORE_VERSION)/Docs/Sample.plist' to 'OC/Sample.plist'..."
 ifeq "$(shell command -v wget)" ""
 	$(error Cannot find wget)
 endif
-	@wget -nv -c https://raw.githubusercontent.com/acidanthera/OpenCorePkg/master/Docs/Sample.plist -O ./OC/Sample.plist
+	@wget -nv -c https://raw.githubusercontent.com/acidanthera/OpenCorePkg/$(REQUIRED_OPENCORE_VERSION)/Docs/Sample.plist -O ./OC/Sample.plist
 	@ls -lah ./OC/Sample.plist
 
 .PHONY: run

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PRINT_TARGET = @echo "--> $@"
 # Default make goal
 .DEFAULT_GOAL := help
 # Required OpenCore version
-REQUIRED_OPENCORE_VERSION = $(shell grep 'readonly OPENCORE_VERSION=' create-efi.sh | awk -F'"' '{ print $$2; }')
+REQUIRED_OPENCORE_VERSION := $(shell grep 'readonly OPENCORE_VERSION=' create-efi.sh | awk -F'"' '{ print $$2; }')
 
 ## Targets
 .PHONY: clean

--- a/OC/config.plist
+++ b/OC/config.plist
@@ -231,6 +231,8 @@
 			<integer>0</integer>
 			<key>RebuildAppleMemoryMap</key>
 			<true/>
+			<key>ResizeAppleGpuBars</key>
+			<integer>-1</integer>
 			<key>SetupVirtualMap</key>
 			<true/>
 			<key>SignalAppleOS</key>
@@ -1359,6 +1361,8 @@
 			<false/>
 			<key>RequestBootVarRouting</key>
 			<true/>
+			<key>ResizeGpuBars</key>
+			<integer>-1</integer>
 			<key>TscSyncTimeout</key>
 			<integer>0</integer>
 			<key>UnblockFsConnect</key>

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You may find great installation guide [here](https://dortania.github.io/OpenCore
 
 ## OpenCore
 
-- [OpenCore 0.7.4](https://github.com/acidanthera/OpenCorePkg/releases/tag/0.7.4)
+- [OpenCore 0.7.5](https://github.com/acidanthera/OpenCorePkg/releases/tag/0.7.5)
 - [Dortania OpenCore Install Guide](https://dortania.github.io/OpenCore-Install-Guide/)
 - [Desktop Coffee Lake](https://dortania.github.io/OpenCore-Install-Guide/config.plist/coffee-lake.html)
 - [OpenCanopy](https://dortania.github.io/OpenCore-Post-Install/cosmetic/gui.html)
@@ -109,11 +109,11 @@ Resulting [USBMap.kext](Kexts/USBMap.kext) is used.
 
 ### Kext
 
-- [AppleALC 1.6.5](https://github.com/acidanthera/AppleALC/releases/tag/1.6.5)
+- [AppleALC 1.6.6](https://github.com/acidanthera/AppleALC/releases/tag/1.6.6)
 - [IntelMausi 1.0.7](https://github.com/acidanthera/IntelMausi/releases/tag/1.0.7)
-- [Lilu 1.5.6](https://github.com/acidanthera/Lilu/releases/tag/1.5.6)
+- [Lilu 1.5.7](https://github.com/acidanthera/Lilu/releases/tag/1.5.7)
 - [VirtualSMC 1.2.7](https://github.com/acidanthera/VirtualSMC/releases/tag/1.2.7) (`SMCProcessor.kext`, `SMCSuperIO.kext`)
-- [WhateverGreen 1.5.4](https://github.com/acidanthera/WhateverGreen/releases/tag/1.5.4)
+- [WhateverGreen 1.5.5](https://github.com/acidanthera/WhateverGreen/releases/tag/1.5.5)
 
 ### Resources
 

--- a/create-efi.sh
+++ b/create-efi.sh
@@ -30,12 +30,12 @@ function run-on-trap() {
 }
 
 # Package versions. Set desired versions here.
-readonly OPENCORE_VERSION="0.7.4"
-readonly KEXT_APPLEALC_VERSION="1.6.5"
+readonly OPENCORE_VERSION="0.7.5"
+readonly KEXT_APPLEALC_VERSION="1.6.6"
 readonly KEXT_INTELMAUSI_VERSION="1.0.7"
-readonly KEXT_LILU_VERSION="1.5.6"
+readonly KEXT_LILU_VERSION="1.5.7"
 readonly KEXT_VIRTUALSMC_VERSION="1.2.7"
-readonly KEXT_WHATEVERGREEN_VERSION="1.5.4"
+readonly KEXT_WHATEVERGREEN_VERSION="1.5.5"
 
 # Installation settings
 # Any non-zero value turns on local file copy, instead of downloading.


### PR DESCRIPTION
- Update to OpenCore `0.7.5`
- Fetch OpenCore reference config as per version set in `create-efi.sh`. This addresses issue when configuration in `master` branch differs from latest release.