### PR TITLE
feat: Update OpenCore to `1.0.1`, macOS to `14.6.1` (`23G93`)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Various basic checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
         args:
@@ -21,12 +21,12 @@ repos:
       - id: shellcheck
         additional_dependencies: []
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.39.0
+    rev: v0.41.0
     hooks:
       - id: markdownlint
   # YAML linting
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.34.0
+    rev: v1.35.1
     hooks:
       - id: yamllint
         args:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Build Status](https://github.com/vovinacci/OpenCore-ASUS-ROG-MAXIMUS-XI-HERO/workflows/test/badge.svg)](https://github.com/vovinacci/OpenCore-ASUS-ROG-MAXIMUS-XI-HERO/actions?query=workflow%3Atest++branch%3Amaster+) [![Latest Release](https://img.shields.io/github/v/release/vovinacci/OpenCore-ASUS-ROG-MAXIMUS-XI-HERO)](https://github.com/vovinacci/OpenCore-ASUS-ROG-MAXIMUS-XI-HERO/releases)[![Release date](https://img.shields.io/github/release-date/vovinacci/OpenCore-ASUS-ROG-MAXIMUS-XI-HERO.svg?label=)](https://github.com/vovinacci/OpenCore-ASUS-ROG-MAXIMUS-XI-HERO/releases)
 
-`EFI` folder based on [OpenCore 1.0.0](https://github.com/acidanthera/OpenCorePkg/releases/tag/1.0.0) for ASUS ROG MAXIMUS XI HERO, Intel Core i9-9900K, and
+`EFI` folder based on [OpenCore 1.0.1](https://github.com/acidanthera/OpenCorePkg/releases/tag/1.0.1) for ASUS ROG MAXIMUS XI HERO, Intel Core i9-9900K, and
 Sapphire Radeon RX 580.
 
-Currently running macOS Sonoma `14.5` (`23F79`) with FileVault 2 enabled.
+Currently running macOS Sonoma `14.6.1` (`23G93`) with FileVault 2 enabled.
 
 ## Installation
 

--- a/create-efi.sh
+++ b/create-efi.sh
@@ -27,12 +27,12 @@ function run-on-trap() {
 }
 
 # Package versions. Set desired versions here.
-readonly OPENCORE_VERSION="1.0.0"
-readonly KEXT_APPLEALC_VERSION="1.9.0"
+readonly OPENCORE_VERSION="1.0.1"
+readonly KEXT_APPLEALC_VERSION="1.9.1"
 readonly KEXT_INTELMAUSI_VERSION="1.0.7"
-readonly KEXT_LILU_VERSION="1.6.7"
-readonly KEXT_VIRTUALSMC_VERSION="1.3.2"
-readonly KEXT_WHATEVERGREEN_VERSION="1.6.6"
+readonly KEXT_LILU_VERSION="1.6.8"
+readonly KEXT_VIRTUALSMC_VERSION="1.3.3"
+readonly KEXT_WHATEVERGREEN_VERSION="1.6.7"
 
 # Installation settings
 # Any non-zero value turns on local file copy, instead of downloading.

--- a/docs/opencore.md
+++ b/docs/opencore.md
@@ -37,11 +37,11 @@ Resulting [USBMap.kext](../Kexts/USBMap.kext) is used.
 
 ## Kext
 
-- [AppleALC 1.9.0](https://github.com/acidanthera/AppleALC/releases/tag/1.9.0)
+- [AppleALC 1.9.1](https://github.com/acidanthera/AppleALC/releases/tag/1.9.1)
 - [IntelMausi 1.0.7](https://github.com/acidanthera/IntelMausi/releases/tag/1.0.7)
-- [Lilu 1.6.7](https://github.com/acidanthera/Lilu/releases/tag/1.6.7)
-- [VirtualSMC 1.3.2](https://github.com/acidanthera/VirtualSMC/releases/tag/1.3.2) (`SMCProcessor.kext`, `SMCSuperIO.kext`)
-- [WhateverGreen 1.6.6](https://github.com/acidanthera/WhateverGreen/releases/tag/1.6.6)
+- [Lilu 1.6.8](https://github.com/acidanthera/Lilu/releases/tag/1.6.8)
+- [VirtualSMC 1.3.3](https://github.com/acidanthera/VirtualSMC/releases/tag/1.3.3) (`SMCProcessor.kext`, `SMCSuperIO.kext`)
+- [WhateverGreen 1.6.7](https://github.com/acidanthera/WhateverGreen/releases/tag/1.6.7)
 
 ### Resources
 


### PR DESCRIPTION
- Update OpenCore to `1.0.1`
- Update macOS to `14.6.1` (`23G93`)
- Update `pre-commit` hooks