### PR TITLE
chore(ci): Bump pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: shellcheck
         additional_dependencies: []
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.42.0
+    rev: v0.44.0
     hooks:
       - id: markdownlint
   # YAML linting


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
	- Updated the markdown linting tool in our pre-commit process to its latest version, bringing improved consistency and quality checks for markdown content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->